### PR TITLE
Lock node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ npm test
 
 # Release Notes
 
+## Version 0.1.5
+
+  * [Misc] There are some bugs with later versions of `npm` which are causing
+           issues. Locking us to a known good version of node stops this.
+
 ## Version 0.1.4
 
   * [Misc] Lock down the version numbers of any dependencies

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "author": "Dom Davis <dom.davis@rainbird.ai>",
     "license": "ISC",
     "main": "config.js",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "engines" : {
         "node" : "0.10.30"
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "main": "config.js",
     "version": "0.1.4",
     "engines" : {
-        "node" : ">=0.10.30"
+        "node" : "0.10.30"
     },
     "scripts": {
         "pretest": "rm -rf docs && rm -rf coverage && docco *.js lib/*.js",


### PR DESCRIPTION
We're having problems with bugs in later versions of `npm`. Locking the node version fixes this.